### PR TITLE
Add support for mods like Enchantment Descriptions.

### DIFF
--- a/src/main/resources/assets/sonic_deflect/lang/en_us.json
+++ b/src/main/resources/assets/sonic_deflect/lang/en_us.json
@@ -1,3 +1,4 @@
 {
-  "enchantment.sonic_deflect.sonic_deflect": "Sonic Deflect"
+  "enchantment.sonic_deflect.sonic_deflect": "Sonic Deflect",
+  "enchantment.sonic_deflect.sonic_deflect.desc": "Reflects sonic beam attacks in the direction you are looking."
 }


### PR DESCRIPTION
This PR adds a language key to support mods like [Enchantment Descriptions](https://www.curseforge.com/minecraft/mc-mods/enchantment-descriptions) that show players descriptions of enchantments in-game. 